### PR TITLE
Revamp landing page with glassmorphism style

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,199 @@
-
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import React from 'react';
+
+import Barra from './components/nav';
+import Rodape from './components/footer';
+import HeroLogo from './hero-logo.webp';
+import heroVideo from './hero.mp4';
+import posterChar from './images/posterchar.png';
 
 import './App.scss';
 
-import Compra from './pages/compra';
-import Home from './pages/home';
-import Sobre from './pages/sobre';
-import Midia from './pages/midia';
-import Comunidade from './pages/comunidade';
+const featureCards = [
+  {
+    title: 'Magia viva',
+    description:
+      'Aprimore feitiços, descubra segredos antigos e crie um legado que responde às suas escolhas.',
+  },
+  {
+    title: 'Exploração cinematográfica',
+    description:
+      'Voe sobre o castelo, atravesse a Floresta Proibida e encontre criaturas fantásticas em um mundo aberto vibrante.',
+  },
+  {
+    title: 'Seu estilo, sua casa',
+    description:
+      'Monte poções, personalize varinhas e defina sua jornada com uma identidade visual inspirada na casa escolhida.',
+  },
+];
+
+const houseHighlights = [
+  {
+    name: 'Grifinória',
+    color: 'var(--crimson)',
+    detail: 'Coragem, lealdade e duelos inesquecíveis em salões iluminados por vitrais rubros.',
+  },
+  {
+    name: 'Sonserina',
+    color: 'var(--emerald)',
+    detail: 'Ambição estratégica, alianças poderosas e a arte das poções levada ao limite.',
+  },
+  {
+    name: 'Corvinal',
+    color: 'var(--cobalt)',
+    detail: 'Intelecto aguçado, enigmas antigos e a biblioteca secreta que guarda tomos proibidos.',
+  },
+  {
+    name: 'Lufa-Lufa',
+    color: 'var(--amber)',
+    detail: 'Resiliência, amizade verdadeira e estufas cheias de ingredientes raros.',
+  },
+];
 
 function App() {
   return (
-   
-        <Router> 
-          <Routes>
-            <Route path="/" element={<Home/>}/>
-            <Route path="/sobre" element={<Sobre/>}/>
-            <Route path="/midia" element={<Midia/>}/>
-            <Route path="/comunidade" element={<Comunidade/>}/>
-            <Route path="/compra" element={<Compra/>}/>
-          </Routes>
-        </Router>   
-  
+    <div className="App">
+      <div className="background-gradient" aria-hidden="true" />
+      <Barra />
+      <main>
+        <section className="hero" id="inicio">
+          <div className="hero-media">
+            <video
+              autoPlay
+              muted
+              loop
+              playsInline
+              poster={HeroLogo}
+              src={heroVideo}
+              className="hero-video"
+            />
+            <div className="glass-card hero-badge">
+              <p>Experimente a nova geração de Hogwarts</p>
+              <span>4K • Haptic Feedback • Ray Tracing</span>
+            </div>
+          </div>
+          <div className="hero-copy glass-card">
+            <p className="eyebrow">RPG imersivo • Século XIX</p>
+            <h1>Hogwarts Legacy</h1>
+            <p className="lead">
+              Reviva a magia com um visual de vidro translúcido, inspirado no glasmorphism, e explore um mundo
+              aberto cheio de histórias inéditas.
+            </p>
+            <div className="hero-actions">
+              <a
+                className="button primary"
+                href="https://www.hogwartslegacy.com/pt-br/purchase"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Comprar agora
+              </a>
+              <a className="button ghost" href="#galeria">
+                Ver trailer e mídia
+              </a>
+            </div>
+          </div>
+        </section>
 
+        <section className="feature-grid" id="experiencia">
+          {featureCards.map((item) => (
+            <article key={item.title} className="glass-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="split" id="historia">
+          <div className="glass-card story">
+            <p className="eyebrow">Legado em vidro</p>
+            <h2>Construa sua narrativa</h2>
+            <p>
+              Explore Hogwarts e seus arredores com uma estética moderna que mistura névoa, brilho e transparências.
+              Cada decisão desbloqueia caminhos únicos, professores exclusivos e inimigos surpreendentes.
+            </p>
+            <ul>
+              <li>Salas Comuns com ambientação dinâmica e iluminação volumétrica.</li>
+              <li>Companheiros com histórias paralelas que reagem às suas escolhas.</li>
+              <li>Montarias mágicas para explorar o mapa em tempo real.</li>
+            </ul>
+            <div className="cta-row">
+              <a className="button ghost" href="#comunidade">
+                Comunidade oficial
+              </a>
+              <a className="button text" href="https://cdn-hogwartslegacy.warnerbrosgames.com/community/downloads/wallpapers.zip">
+                Baixar wallpapers
+              </a>
+            </div>
+          </div>
+          <div className="glass-card media-card" id="galeria">
+            <img src={posterChar} alt="Personagens de Hogwarts Legacy" className="media-image" />
+            <div className="media-overlay">
+              <p>Descubra os segredos de 1890 em Hogwarts</p>
+              <span>Capturas em tempo real do PS5</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="house-grid" id="casas">
+          <h2>Escolha sua casa</h2>
+          <div className="house-cards">
+            {houseHighlights.map((house) => (
+              <article key={house.name} className="glass-card house-card">
+                <div className="house-accent" style={{ background: house.color }} />
+                <div>
+                  <h3>{house.name}</h3>
+                  <p>{house.detail}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="cta" id="comunidade">
+          <div className="glass-card cta-card">
+            <div>
+              <p className="eyebrow">Comunidade global</p>
+              <h2>Junte-se aos bruxos e bruxas</h2>
+              <p>
+                Entre nos canais oficiais para receber novidades, compartilhar capturas com a estética de vidro e
+                participar de eventos exclusivos.
+              </p>
+              <div className="social-links">
+                <a href="https://discord.com/invite/HogwartsLegacy" className="pill" target="_blank" rel="noreferrer">
+                  Discord
+                </a>
+                <a href="https://www.youtube.com/HogwartsLegacy" className="pill" target="_blank" rel="noreferrer">
+                  YouTube
+                </a>
+                <a href="https://twitter.com/HogwartsLegacy" className="pill" target="_blank" rel="noreferrer">
+                  Twitter/X
+                </a>
+                <a
+                  href="https://www.instagram.com/HogwartsLegacy/"
+                  className="pill"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Instagram
+                </a>
+              </div>
+            </div>
+            <div className="cta-actions">
+              <a
+                className="button primary"
+                href="https://cdn-hogwartslegacy.warnerbrosgames.com/community/downloads/wallpapers.zip"
+              >
+                Download de artes
+              </a>
+              <a className="button ghost" href="#inicio">
+                Voltar ao topo
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Rodape />
+    </div>
   );
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,191 +1,328 @@
-@import url('https://fonts.googleapis.com/css2?family=Merienda:wght@700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Macondo&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
-*{
+:root {
+  --glass: rgba(255, 255, 255, 0.12);
+  --glass-strong: rgba(255, 255, 255, 0.18);
+  --border: rgba(255, 255, 255, 0.28);
+  --text: #e9ecf5;
+  --muted: #cbd5f5;
+  --shadow: 0 20px 70px rgba(0, 0, 0, 0.35);
+  --crimson: linear-gradient(135deg, #f06b6b, #ffb199);
+  --emerald: linear-gradient(135deg, #50c9c3, #96deda);
+  --cobalt: linear-gradient(135deg, #4a6cf7, #9e8bff);
+  --amber: linear-gradient(135deg, #f7b733, #fc4a1a);
+}
+
+* {
   box-sizing: border-box;
   padding: 0;
   margin: 0;
-  text-decoration: none;
 }
 
 body {
-  font-size: 100%;
-  background: linear-gradient(69deg, #2F4F4F	23%, #87CEFA 80%);
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0d0f1a;
+  color: var(--text);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
 }
 
+.App {
+  position: relative;
+  overflow: hidden;
+}
 
+.background-gradient {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(102, 126, 234, 0.24), transparent 35%),
+    radial-gradient(circle at 80% 10%, rgba(237, 100, 166, 0.25), transparent 35%),
+    radial-gradient(circle at 50% 80%, rgba(16, 185, 129, 0.2), transparent 40%),
+    linear-gradient(120deg, rgba(16, 24, 39, 0.9), rgba(13, 15, 26, 0.9));
+  filter: blur(18px);
+  transform: scale(1.05);
+  z-index: 0;
+}
 
-/*Main*/
+main {
+  position: relative;
+  z-index: 1;
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  padding: 120px 0 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 72px;
+}
 
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+  align-items: center;
+}
 
+.hero-media {
+  position: relative;
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
 
-.trailer-video {
+.hero-video {
   width: 100%;
   height: 100%;
+  object-fit: cover;
+  display: block;
+  filter: saturate(1.1) brightness(1.1);
 }
 
-.center {
-  margin-bottom: 48px;
-  border-top: 0.4px solid #FFF2E7;
+.hero-badge {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  backdrop-filter: blur(18px);
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--glass);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
 }
 
-.center-prime {
+.hero-badge p {
+  font-weight: 600;
+}
+
+.hero-badge span {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.hero-copy {
+  padding: 28px;
+}
+
+.glass-card {
+  background: var(--glass);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  backdrop-filter: blur(20px);
+  box-shadow: var(--shadow);
+}
+
+.hero-copy h1 {
+  font-size: clamp(36px, 5vw, 56px);
+  letter-spacing: 0.5px;
+}
+
+.lead {
+  margin: 18px 0 24px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 12px;
+  color: #9fb7ff;
+  margin-bottom: 10px;
+  font-weight: 700;
+}
+
+.hero-actions {
   display: flex;
-  flex-direction: row-reverse;
-  align-items: center;
-  justify-content: space-around;
-  margin: 0% auto;
+  gap: 14px;
+  flex-wrap: wrap;
 }
 
-.center-prime-texto {
-  max-width: 70%;
+.button {
+  border-radius: 14px;
+  padding: 12px 18px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, #7f5af0, #8ec5fc);
+  color: #0a0c18;
+  box-shadow: 0 15px 50px rgba(127, 90, 240, 0.35);
+}
+
+.button.ghost {
+  background: var(--glass-strong);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.button.text {
+  background: transparent;
+  border-color: transparent;
+  color: #9fb7ff;
+  padding-left: 0;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.feature-grid article {
+  padding: 20px 22px;
+  line-height: 1.5;
+}
+
+.feature-grid h3 {
+  margin-bottom: 10px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+  align-items: stretch;
+}
+
+.story {
+  padding: 26px;
+  line-height: 1.65;
+}
+
+.story ul {
+  margin-top: 16px;
+  margin-left: 16px;
+  color: var(--muted);
+  display: grid;
+  gap: 8px;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.media-card {
+  position: relative;
+  padding: 0;
+  overflow: hidden;
+}
+
+.media-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.media-overlay {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 18px;
+  background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.7));
+  color: var(--muted);
+}
+
+.house-grid {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 18px;
 }
 
-.center-prime-texto-titulo {
-  font-family: 'Macondo', cursive;
-  font-weight: 300;
-  font-size: 44px;
-  color: #FFF2E7;
+.house-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
 }
 
-.center-prime-texto-subtitulo {
-  font-family: 'Righteous', cursive;
-  font-weight: 400;
-  font-size: 24px;
-  color: #ECD6C4;
-}
-
-.center-prime-texto-botao {
-  background-color: #ECD6C4;
-  width: 180px;
-  height: 60px;
-  border: none;
-  box-shadow: 4px 5px 4px rgba(0, 0, 0, 0.25);
-  border-radius: 20px;
-  font-family: 'Sarala', sans-serif;
-  font-weight: 400;
-  font-size: 24px;
-  color: #2F2325;
-}
-
-.center-prime-texto-botao:hover {
-  background-color: rgba(236, 214, 196, 0.53);
-}
-
-.center-prime-imagem {
-  height: 430px;
-  max-width: 50%;
-  max-height: 50%;
-}
-
-
-.center-corpo {
-  display: flex;
-  flex-direction: column;
+.house-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  padding: 16px;
   align-items: center;
-  gap: 24px;
-  margin-top: 48px;
 }
 
-.center-corpo-titulo {
-  border-top: 0.4px solid #FFF2E7;
-  padding-top: 48px;
-  font-family: 'Macondo', cursive;
-  font-weight: 300;
-  font-size: 20px;
-  color: #FFF2EF;
-  margin-bottom: 16px;
+.house-card h3 {
+  margin-bottom: 8px;
 }
 
-.center-corpo-paragrafo {
-  font-family: 'Sarala', sans-serif;
-  font-weight: 300;
-  font-size: 18px;
-  color: #ECD6C4;
-}
-/*Sobre*/
-.center-sobre {
-  margin-bottom: 48px;
-  padding-top: 150px;
-  border-top: 0.4px solid #FFF2E7;
-  background: linear-gradient(69deg, #2F4F4F	23%, #191970 80%);
+.house-accent {
+  width: 6px;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #7f5af0, #8ec5fc);
 }
 
-
-/*Comunidade*/
-.center-corpo-comu {
+.cta {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  margin-top: 48px;
-}
-
-.rede-img {
   justify-content: center;
+}
+
+.cta-card {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+  padding: 24px;
   align-items: center;
-  height: 50px;
-  max-width: 50%;
-  max-height: 50%;
 }
 
-/*Midia*/
-
-.center-midia {
-  background: linear-gradient(69deg, #2F4F4F	23%, rgb(147, 177, 194) 80%);
+.social-links {
   display: flex;
-  align-items: center;
-  justify-content: space-around;
-  flex-direction: column;
-  margin-bottom: 48px;
-  border-top: 0.4px solid #FFF2E7;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
 }
 
-
-
-
-.center-midia-texto {
-  font-family: 'Macondo', cursive;
-  gap: 24px;
-  margin-top: 48px;
-  margin-bottom: 48px;
+.pill {
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--glass-strong);
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
 }
 
-.carousel-inner{
-  margin: 0% auto;
+.pill:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
 }
 
-.carousel-item {
-  margin: 20px auto;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-
-.carousel-caption {
-  font-family: 'Macondo', cursive;
-  font-weight: 300;
-  font-size: 18px;
-  color: #ECD6C4;  
-}
-
-/*
-.center-midia-video {
-  max-width: 70%;
+.cta-actions {
   display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  padding-left: 50px;
-  padding-right: 50px;
+  gap: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
-.center-midia-item {
-  margin: 20px auto;
-  padding-left: 10px;
-  padding-right: 10px;
+@media (max-width: 768px) {
+  main {
+    padding: 96px 0 64px;
+    gap: 56px;
+  }
+
+  .hero,
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-badge {
+    right: 12px;
+    left: 12px;
+  }
+
+  .cta-card {
+    text-align: left;
+  }
 }
-*/

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renderiza o título principal', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /hogwarts legacy/i });
+  expect(heading).toBeInTheDocument();
 });
+

--- a/src/components/Footer.scss
+++ b/src/components/Footer.scss
@@ -1,18 +1,36 @@
-/*Footer*/
 .rodape {
-    width: 100%;
-    padding: 8px 28px;
-    border-top: 0.4px solid #FFF2E7;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    gap: 2.5px;
-    color: #FFF2E7;
+  width: 100%;
+  padding: 24px 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.22);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  color: #e9ecf5;
+  background: rgba(10, 12, 24, 0.7);
+  backdrop-filter: blur(12px);
+}
+
+.rodape-copy span {
+  color: #a9b6d8;
 }
 
 .rodape-media {
-  height: 48px;  
-  margin: 0 auto;
+  display: flex;
+  gap: 12px;
+}
+
+.rodape-media img {
+  height: 36px;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.35));
+}
+
+.rodape-media a {
+  transition: transform 0.2s ease;
+}
+
+.rodape-media a:hover {
+  transform: translateY(-2px) scale(1.02);
 }

--- a/src/components/Nav.scss
+++ b/src/components/Nav.scss
@@ -1,31 +1,71 @@
-/*Nav*/
 .barra {
-    /*background-image: url('https://cdn-hogwartslegacy.warnerbrosgames.com/static/mobile-nav-bg.jpg');*/
-    background: linear-gradient(69deg, #87CEFA	23%, #2F4F4F 80%);
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding: 14px;
-    margin: 0 auto;
+  position: sticky;
+  top: 18px;
+  z-index: 5;
+  margin: 0 auto 12px;
+  width: min(1200px, 92vw);
+  padding: 14px 18px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(13, 15, 26, 0.55);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 16px 45px rgba(0, 0, 0, 0.35);
+}
+
+.logo-wrap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo-title {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #f0f4ff;
+}
+
+.nav-logo {
+  height: 46px;
+  width: auto;
+}
+
+.barra-menu {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.barra-menu-item {
+  color: #e9ecf5;
+  font-weight: 600;
+  text-decoration: none;
+  padding: 10px 12px;
+  border-radius: 12px;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.barra-menu-item:hover {
+  border-color: rgba(255, 255, 255, 0.32);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+@media (max-width: 768px) {
+  .barra {
+    flex-direction: column;
+    gap: 12px;
+    top: 8px;
   }
-  /*
-  #id-barra {
-    opacity: 50%;
-  }*/
-  
-  .nav-logo {
-    height: 50px;
+
+  .logo-title {
+    font-size: 14px;
   }
-  
+
   .barra-menu {
-    display: flex;
-    gap: 30px;
+    justify-content: center;
   }
-  
-  .barra-menu-item {
-    color: whitesmoke;
-    font-family: 'Merienda', cursive;
-    font-weight: 800;
-    font-size: 18px;
-  }
+}

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -1,18 +1,31 @@
+import React from 'react';
+
 import Github from '../images/github.png';
 import Linkedin from '../images/linkedin.png';
 import './Footer.scss';
 
 function Rodape() {
-    return (
-        <footer class="rodape">
-        <p>Hogwarts Legacy Fake Page</p>
-        <span>Desenvolvido por Marcos Castro</span>
-        <div class="rodape-media">
-          <a href="https://github.com/MarcosCast"><img src={Linkedin} alt="github"/></a>
-          <a href="https://www.linkedin.com/in/marcos--castro/"><img src={Github} alt="linkedin"/></a>
-        </div>
-        </footer>        
-    )    
+  return (
+    <footer className="rodape">
+      <div className="rodape-copy">
+        <p>Hogwarts Legacy — experiência conceitual em glasmorphism.</p>
+        <span>Construído por Marcos Castro.</span>
+      </div>
+      <div className="rodape-media" aria-label="Perfis do desenvolvedor">
+        <a href="https://github.com/MarcosCast" aria-label="GitHub" target="_blank" rel="noreferrer">
+          <img src={Github} alt="Github" />
+        </a>
+        <a
+          href="https://www.linkedin.com/in/marcos--castro/"
+          aria-label="LinkedIn"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <img src={Linkedin} alt="LinkedIn" />
+        </a>
+      </div>
+    </footer>
+  );
 }
 
 export default Rodape;

--- a/src/components/nav.jsx
+++ b/src/components/nav.jsx
@@ -1,24 +1,37 @@
-import { Link } from 'react-router-dom';
-//import logo from '../logo.svg';
+import React from 'react';
+
 import Hero from '../hero-logo.webp';
 import './Nav.scss';
 
 function Barra() {
-    return(
-      <header id="id-barra" className="barra">
-          <a href="index.html" /*role="menuitem" aria-label="Home Page" */>
-            <Link to="/"><img src={Hero} className="nav-logo" alt="Logo Hogwarts Legacy"/></Link>
-          </a>
+  return (
+    <header className="barra">
+      <div className="logo-wrap">
+        <a href="#inicio" aria-label="Início">
+          <img src={Hero} className="nav-logo" alt="Logo Hogwarts Legacy" />
+        </a>
+        <span className="logo-title">Hogwarts Legacy</span>
+      </div>
 
-          <nav id='MainNav' /*data-toggle="collapse" data-target=".nav-collapse"*/ className="barra-menu">
-          <ul id='menu'>
-           <a className="barra-menu-item" href='Sobre' ><Link to="/sobre"> Sobre </Link></a>
-           <a className="barra-menu-item" href='Midia' ><Link to="/midia"> Mídia </Link></a>
-           <a className="barra-menu-item" href='Comunidade' ><Link to="/comunidade"> Comunidade </Link></a>
-         </ul>    
+      <nav className="barra-menu" aria-label="Navegação principal">
+        <a className="barra-menu-item" href="#experiencia">
+          Experiência
+        </a>
+        <a className="barra-menu-item" href="#historia">
+          Narrativa
+        </a>
+        <a className="barra-menu-item" href="#galeria">
+          Galeria
+        </a>
+        <a className="barra-menu-item" href="#casas">
+          Casas
+        </a>
+        <a className="barra-menu-item" href="#comunidade">
+          Comunidade
+        </a>
       </nav>
-      </header>
-    )
+    </header>
+  );
 }
 
 export default Barra;


### PR DESCRIPTION
## Summary
- rebuild the landing page with a single-page glassmorphism-inspired layout featuring hero, story, house, and community sections
- refresh navigation and footer components with translucent styling and in-page anchors
- update styling system and tests to align with the new layout and copy

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c678fe188333af1a8d5c511e87f9)